### PR TITLE
Fixes for GCC 6

### DIFF
--- a/src/graphics/GraphicsHelpers.cpp
+++ b/src/graphics/GraphicsHelpers.cpp
@@ -89,7 +89,7 @@ void SetupRenderMode( RenderMode renderMode, const bool bBackfaceCulling )
 
 void DrawFloorQuad( float flSideLength )
 {
-	flSideLength = abs( flSideLength );
+	flSideLength = std::abs( flSideLength );
 
 	glBegin( GL_TRIANGLE_STRIP );
 	glTexCoord2f( 0.0f, 0.0f );

--- a/src/tools/hlmv/settings/CHLMVSettings.cpp
+++ b/src/tools/hlmv/settings/CHLMVSettings.cpp
@@ -12,6 +12,8 @@
 
 #include "CHLMVSettings.h"
 
+#include <cmath>
+
 namespace hlmv
 {
 const size_t CHLMVSettings::MAX_RECENT_FILES = 4;


### PR DESCRIPTION
This PR fixes compile errors under GCC 6.

A word of warning, the fixes might be dirty and may break Windows builds.